### PR TITLE
VEOSS-872 | Return NOT_FOUND when empty Seq returned from Mongo

### DIFF
--- a/app/controllers/SaveForLaterController.scala
+++ b/app/controllers/SaveForLaterController.scala
@@ -44,7 +44,9 @@ class SaveForLaterController @Inject()(
   def get(): Action[AnyContent] = auth.async {
     implicit request =>
       saveForLaterService.get(request.vrn).map {
-        value => Ok(Json.toJson(value.sortBy(_.lastUpdated).lastOption))
+        value => value.sortBy(_.lastUpdated).lastOption
+          .map(savedUserAnswers => Ok(Json.toJson(savedUserAnswers)))
+          .getOrElse(NotFound)
       }
   }
 

--- a/test/controllers/SaveForLaterControllerSpec.scala
+++ b/test/controllers/SaveForLaterControllerSpec.scala
@@ -113,6 +113,26 @@ class SaveForLaterControllerSpec
         verify(mockService, times(1)).get(any())
       }
     }
+
+    "must return NOT_FOUND when no answers are found" in {
+      val mockService = mock[SaveForLaterService]
+
+      when(mockService.get(any()))
+        .thenReturn(Future.successful(Seq()))
+
+      val app =
+        applicationBuilder
+          .overrides(bind[SaveForLaterService].toInstance(mockService))
+          .build()
+
+      running(app) {
+
+        val result = route(app, request).value
+
+        status(result) mustEqual NOT_FOUND
+        verify(mockService, times(1)).get(any())
+      }
+    }
   }
 
   ".delete" - {


### PR DESCRIPTION
When there are no results, Mongo returns an empty Seq. the .lastOption within the Json.toJson was converted to JSON as null. This was returned to frontend as OK(null), which triggered the Invalid JSON error.

Instead, move .lastOption outside Json.toJson and return a NOT_FOUND response if it's empty.